### PR TITLE
Support access to drag sort item element

### DIFF
--- a/addon/components/drag-sort-list.js
+++ b/addon/components/drag-sort-list.js
@@ -28,6 +28,7 @@ export default Component.extend({
 
   dragEndAction                  : undefined,
   determineForeignPositionAction : undefined,
+  yieldDragSortItemComponent     : false,
 
 
 

--- a/addon/templates/components/drag-sort-list.hbs
+++ b/addon/templates/components/drag-sort-list.hbs
@@ -1,6 +1,8 @@
 {{#each items as |item index|}}
   {{#if yieldDragSortItemComponent}}
     {{yield (hash 
+      data=item
+      index=index
       Component=(component 'drag-sort-item'
         item=item
         index=index

--- a/addon/templates/components/drag-sort-list.hbs
+++ b/addon/templates/components/drag-sort-list.hbs
@@ -1,16 +1,33 @@
 {{#each items as |item index|}}
-  {{#drag-sort-item
-    item                           = item
-    index                          = index
-    items                          = items
-    group                          = group
-    handle                         = handle
-    class                          = childClass
-    tagName                        = childTagName
-    draggingEnabled                = draggingEnabled
-    dragEndAction                  = dragEndAction
-    determineForeignPositionAction = determineForeignPositionAction
-  }}
-    {{yield item index}}
-  {{/drag-sort-item}}
+  {{#if yieldDragSortItemComponent}}
+    {{yield (hash 
+      Component=(component 'drag-sort-item'
+        item=item
+        index=index
+        items=items
+        group=group
+        handle=handle
+        class=childClass
+        tagName=childTagName
+        draggingEnabled=draggingEnabled
+        dragEndAction=dragEndAction
+        determineForeignPositionAction=determineForeignPositionAction
+      )
+    )}}
+  {{else}}
+    {{#drag-sort-item
+      item                           = item
+      index                          = index
+      items                          = items
+      group                          = group
+      handle                         = handle
+      class                          = childClass
+      tagName                        = childTagName
+      draggingEnabled                = draggingEnabled
+      dragEndAction                  = dragEndAction
+      determineForeignPositionAction = determineForeignPositionAction
+    }}
+      {{yield item index}}
+    {{/drag-sort-item}}
+  {{/if}}
 {{/each}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -329,7 +329,7 @@
     as |item|
   }}
     {{#item.Component}}
-      Hello, World!
+      Hello, {{item.data}}!
     {{/item.Component}}
   {{/drag-sort-list}}
 </div>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -315,3 +315,21 @@
     dragEndAction = (action 'dragEnd')
   }}
 </div>
+
+
+<div class="list-group-wrapper">
+  <h2>HERE</h2>
+
+  {{#drag-sort-list
+    items         = items11
+    tagName       = 'table'
+    group         = 'table'
+    dragEndAction = (action 'dragEnd')
+    yieldDragSortItemComponent = true
+    as |item|
+  }}
+    {{#item.Component}}
+      Hello, World!
+    {{/item.Component}}
+  {{/drag-sort-list}}
+</div>

--- a/tests/integration/components/drag-sort-list-test.js
+++ b/tests/integration/components/drag-sort-list-test.js
@@ -214,3 +214,64 @@ test('nested drag handle', withChai(async function (expect) {
     targetIndex : 1
   })
 }))
+
+test('customize internal dragSortItem wrapper', withChai(async function (expect) {
+  const items = A([
+    {name : 'foo'},
+    {name : 'bar'},
+    {name : 'baz'},
+  ])
+
+  const dragEndCallback = sinon.spy()
+
+  this.setProperties({items, dragEndCallback})
+
+  this.render(hbs`
+    {{#drag-sort-list
+      items         = items
+      dragEndAction = (action dragEndCallback)
+      yieldDragSortItemComponent = true
+      as |item|
+    }}
+      {{#item.Component class="foo"}}
+        <div class="handle">
+          <div class="handle2">handle</div>
+        </div>
+        <div>
+          {{item.name}}
+        </div>
+      {{/item.Component}}
+    {{/drag-sort-list}}
+  `)
+
+  // check for custom class in addition to internal class. Test that drag and drop sorting still works
+  const $item0 = this.$('.dragSortItem.foo:eq(0)')
+  const $item1 = this.$('.dragSortItem.foo:eq(1)')
+
+  // const itemOffset = $item0.offset()
+
+  trigger($item0, 'dragstart')
+  trigger($item1, 'dragover', false)
+  trigger($item0, 'dragend')
+
+  await wait()
+
+  expect(dragEndCallback).not.called
+
+  trigger($item0.find('.handle2'), 'dragstart')
+  trigger($item1, 'dragover', false)
+  trigger($item0, 'dragend')
+
+  await wait()
+
+  expect(dragEndCallback).calledOnce
+
+  expect(dragEndCallback).calledWithExactly({
+    group       : undefined,
+    draggedItem : items.objectAt(0),
+    sourceList  : items,
+    targetList  : items,
+    sourceIndex : 0,
+    targetIndex : 1
+  })
+}))

--- a/tests/integration/components/drag-sort-list-test.js
+++ b/tests/integration/components/drag-sort-list-test.js
@@ -238,7 +238,7 @@ test('customize internal dragSortItem wrapper', withChai(async function (expect)
           <div class="handle2">handle</div>
         </div>
         <div>
-          {{item.name}}
+          {{item.data.name}}
         </div>
       {{/item.Component}}
     {{/drag-sort-list}}


### PR DESCRIPTION
This PR adds a new feature for the drag-sort-list component.

A new boolean property `yieldDragSortItemComponent` may be set on the list component.
Defaults to false.
If true, the component yields a hash with the following properties:
`data` the data representing the item being iterated over
`index` the item's index
`Component` the internal `drag-sort-item` component for easy customizability

example usage:

```
{{#drag-sort-list
    items         = items
    dragEndAction = (action dragEndCallback)
    yieldDragSortItemComponent = true
    as |item|
}}
     {{#item.Component class="foo"}} {{!-- "foo" will be added as a class name in addition to internal class names --}}
        <div class="handle">
          <div class="handle2">handle</div>
        </div>
        <div>
          {{item.data.name}}
        </div>
    {{/item.Component}}
{{/drag-sort-list}}
```